### PR TITLE
ssl context

### DIFF
--- a/requests_pkcs12.py
+++ b/requests_pkcs12.py
@@ -36,7 +36,7 @@ def check_cert_not_after(cert):
     if cert_not_after < datetime.utcnow():
         raise ValueError('Client certificate expired: Not After: {cert_not_after:%Y-%m-%d %H:%M:%SZ}'.format(**locals()))
 
-def create_pyopenssl_ssl_context(pkcs12_data, pkcs12_password_bytes):
+def create_pyopenssl_sslcontext(pkcs12_data, pkcs12_password_bytes):
     p12 = load_pkcs12(pkcs12_data, pkcs12_password_bytes)
     cert = p12.get_certificate()
     check_cert_not_after(cert)
@@ -50,7 +50,7 @@ def create_pyopenssl_ssl_context(pkcs12_data, pkcs12_password_bytes):
     ssl_context._ctx.use_privatekey(p12.get_privatekey())
     return ssl_context
 
-def create_ssl_ssl_context(pkcs12_data, pkcs12_password_bytes):
+def create_ssl_sslcontext(pkcs12_data, pkcs12_password_bytes):
     cipher = 'blowfish'
     p12 = load_pkcs12(pkcs12_data, pkcs12_password_bytes)
     cert = p12.get_certificate()

--- a/requests_pkcs12.py
+++ b/requests_pkcs12.py
@@ -96,7 +96,7 @@ class Pkcs12Adapter(HTTPAdapter):
             pkcs12_password_bytes = pkcs12_password
         else:
             pkcs12_password_bytes = pkcs12_password.encode('utf8')
-        self.ssl_context = create_pyopenssl_ssl_context(pkcs12_data, pkcs12_password_bytes)
+        self.ssl_context = create_pyopenssl_sslcontext(pkcs12_data, pkcs12_password_bytes)
         super(Pkcs12Adapter, self).__init__(*args, **kwargs)
 
     def init_poolmanager(self, *args, **kwargs):

--- a/requests_pkcs12.py
+++ b/requests_pkcs12.py
@@ -17,7 +17,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 '''
 
 import os
-from OpenSSL.crypto import load_pkcs12, dump_certificate, dump_privatekey,FILETYPE_PEM
+from OpenSSL.crypto import load_pkcs12, dump_certificate, dump_privatekey, FILETYPE_PEM
 from datetime import datetime
 from requests import Session
 from requests import request as request_orig


### PR DESCRIPTION
Adds a method allowing users to create an `ssl.SSLContext` in addition to a `PyOpenSSL.SSLContext` as discussed in issue #20.