### PR TITLE
Ability to enforce a specific version of TLS protocol

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,4 +62,8 @@ The following keyword arguments are supported:
 
    -  This argument must be provided whenever ``pkcs12_filename`` or ``pkcs12_data`` is provided.
 
+-  ``ssl_protocol`` is a protocol version from the ``ssl`` library.
+
+   -  This argument can be provided whenever, the default value is ``ssl.PROTOCOL_TLS``.
+
 If you use these parameters, don’t use the built-in ``cert`` parameter of ``requests`` at the same time. However, do use the other parameters.  In particular, do use `the "verify" parameter <http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification>`__ to verify the server-side certificate.

--- a/requests_pkcs12.py
+++ b/requests_pkcs12.py
@@ -27,9 +27,9 @@ from ssl import SSLContext
 from tempfile import NamedTemporaryFile
 
 try:
-    from ssl import PROTOCOL_TLS as ssl_protocol
+    from ssl import PROTOCOL_TLS as default_ssl_protocol
 except ImportError:
-    from ssl import PROTOCOL_SSLv23 as ssl_protocol
+    from ssl import PROTOCOL_SSLv23 as default_ssl_protocol
 
 def check_cert_not_after(cert):
     cert_not_after = datetime.strptime(cert.get_notAfter().decode('ascii'), '%Y%m%d%H%M%SZ')
@@ -40,7 +40,7 @@ def create_pyopenssl_sslcontext(pkcs12_data, pkcs12_password_bytes):
     p12 = load_pkcs12(pkcs12_data, pkcs12_password_bytes)
     cert = p12.get_certificate()
     check_cert_not_after(cert)
-    ssl_context = PyOpenSSLContext(ssl_protocol)
+    ssl_context = PyOpenSSLContext(default_ssl_protocol)
     ssl_context._ctx.use_certificate(cert)
     ca_certs = p12.get_ca_certificates()
     if ca_certs:
@@ -55,7 +55,7 @@ def create_ssl_sslcontext(pkcs12_data, pkcs12_password_bytes):
     p12 = load_pkcs12(pkcs12_data, pkcs12_password_bytes)
     cert = p12.get_certificate()
     check_cert_not_after(cert)
-    ssl_context = SSLContext(ssl_protocol)
+    ssl_context = SSLContext(default_ssl_protocol)
     with NamedTemporaryFile(delete=False) as c:
         try:
             pk_buf = dump_privatekey(FILETYPE_PEM, p12.get_privatekey(), cipher, pkcs12_password_bytes)


### PR DESCRIPTION
Hey, I needed support for a specific version of TLS (TLS1.2), with that PR everyone will be able to enforce the desired ssl protocol.