### PR TITLE
Increase urllib3 min version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         'cryptography (>=3.4.7)',
         'pyOpenSSL (>=20.0.1)',
         'requests (>=2.26.0)',
+        'urllib3 (>=1.26.13,<2.0)',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Closes #36 by explicitly including a minimum version of urllib3 as a requirement and bounding the version as <2.0.