### PR TITLE
Increase urllib3 max version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         'cryptography (>=3.4.7)',
         'pyOpenSSL (>=20.0.1)',
         'requests (>=2.26.0)',
-        'urllib3 (>=1.26.13,<2.0)',
+        'urllib3 (>=1.26.13,<2.1)',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Tested with Python 3.7 to 3.11.

`urllib3<2.1` because that's when urllib3.contrib.pyopenssl will be removed.