### PR TITLE
FIX error AttributeError: '_Certificate' object has no attribute 'not…

### DIFF
--- a/requests_pkcs12.py
+++ b/requests_pkcs12.py
@@ -34,8 +34,9 @@ except ImportError:
     from ssl import PROTOCOL_SSLv23 as default_ssl_protocol
 
 def _check_cert_not_after(cert):
-    cert_not_after = cert.not_valid_after_utc
-    if cert_not_after < datetime.datetime.now(datetime.timezone.utc):
+    cert_not_after = cert.not_valid_after
+    #if cert_not_after < datetime.datetime.now(datetime.timezone.utc):
+    if cert_not_after.replace(tzinfo=datetime.timezone.utc) < datetime.datetime.now(datetime.timezone.utc):
         raise ValueError('Client certificate expired: Not After: {cert_not_after:%Y-%m-%d %H:%M:%SZ}'.format(**locals()))
 
 def _create_sslcontext(pkcs12_data, pkcs12_password_bytes, ssl_protocol):


### PR DESCRIPTION
ERROR : AttributeError: '_Certificate' object has no attribute 'not_valid_after_utc'. Did you mean: 'not_valid_after'?

environment : Python 3.10 (not have that error on python 3.12)
cryptography==44.0.0
requests==2.32.3
