### PR TITLE
Switch to PKCS8 for PEM serialization

### DIFF
--- a/requests_pkcs12.py
+++ b/requests_pkcs12.py
@@ -50,7 +50,7 @@ def _create_sslcontext(pkcs12_data, pkcs12_password_bytes, ssl_protocol):
             tmp_pkcs12_password_bytes = secrets.token_bytes(128//8)
             pk_buf = private_key.private_bytes(
                 cryptography.hazmat.primitives.serialization.Encoding.PEM,
-                cryptography.hazmat.primitives.serialization.PrivateFormat.TraditionalOpenSSL,
+                cryptography.hazmat.primitives.serialization.PrivateFormat.PKCS8,
                 cryptography.hazmat.primitives.serialization.BestAvailableEncryption(password=tmp_pkcs12_password_bytes)
             )
             c.write(pk_buf)


### PR DESCRIPTION
Resolves #60 

Switch from `TraditionalOpenSSL` to `PKCS8` for temporary PEM serialization. `TraditionalOpenSSL` relies on MD5 for key derivation, which does not work on FIPS enabled systems.